### PR TITLE
Modernize design, reverse chronological order, redistribute images

### DIFF
--- a/all-americans.html
+++ b/all-americans.html
@@ -30,6 +30,14 @@
   <main class="container">
     <section id="all-americans" aria-labelledby="aa-title">
       <h2 id="aa-title">All-Americans</h2>
+
+      <div class="photo-grid" style="margin-bottom:24px">
+        <div class="photo-card"><img src="Images/barron1.png" alt="Barron"></div>
+        <div class="photo-card"><img src="Images/beckman1.png" alt="Beckman"></div>
+        <div class="photo-card"><img src="Images/donny1.png" alt="Donny"></div>
+        <div class="photo-card"><img src="Images/fenstermaker1.png" alt="Fenstermaker"></div>
+      </div>
+
       <div class="grid three">
         <article class="card">
           <h3>First Team</h3>
@@ -47,34 +55,35 @@
         </article>
       </div>
     </section>
-    <div class="photo-section">
-      <p class="photo-section-title">Player Gallery</p>
-      <div class="photo-grid">
-        <div class="photo-card"><img src="Images/barron1.png"       alt="Barron">      <div class="photo-card-label">Barron</div></div>
-        <div class="photo-card"><img src="Images/beckman1.png"      alt="Beckman">     <div class="photo-card-label">Beckman</div></div>
-        <div class="photo-card"><img src="Images/donny1.png"        alt="Donny">       <div class="photo-card-label">Donny</div></div>
-        <div class="photo-card"><img src="Images/fenstermaker1.png" alt="Fenstermaker"><div class="photo-card-label">Fenstermaker</div></div>
-        <div class="photo-card"><img src="Images/gabalski1.png"     alt="Gabalski">    <div class="photo-card-label">Gabalski</div></div>
-        <div class="photo-card"><img src="Images/gasser1.png"       alt="Gasser">      <div class="photo-card-label">Gasser</div></div>
-        <div class="photo-card"><img src="Images/hump1.png"         alt="Hump">        <div class="photo-card-label">Hump</div></div>
-        <div class="photo-card"><img src="Images/kellen1.png"       alt="Kellen">      <div class="photo-card-label">Kellen</div></div>
-        <div class="photo-card"><img src="Images/king1.png"         alt="King">        <div class="photo-card-label">King</div></div>
-        <div class="photo-card"><img src="Images/rive1.png"         alt="Rive">        <div class="photo-card-label">Rive</div></div>
-        <div class="photo-card"><img src="Images/samf1.png"         alt="Sam F.">      <div class="photo-card-label">Sam F.</div></div>
-        <div class="photo-card"><img src="Images/spencer1.png"      alt="Spencer">     <div class="photo-card-label">Spencer</div></div>
-        <div class="photo-card"><img src="Images/white1.png"        alt="White">       <div class="photo-card-label">White</div></div>
-        <div class="photo-card"><img src="Images/zaleski1.png"      alt="Zaleski">     <div class="photo-card-label">Zaleski</div></div>
-      </div>
+
+    <hr class="section-divider">
+
+    <div class="photo-grid" style="margin-bottom:24px">
+      <div class="photo-card"><img src="Images/gabalski1.png" alt="Gabalski"></div>
+      <div class="photo-card"><img src="Images/gasser1.png" alt="Gasser"></div>
+      <div class="photo-card"><img src="Images/hump1.png" alt="Hump"></div>
+      <div class="photo-card"><img src="Images/kellen1.png" alt="Kellen"></div>
+      <div class="photo-card"><img src="Images/king1.png" alt="King"></div>
     </div>
 
     <section id="captains" aria-labelledby="captains-title">
       <h2 id="captains-title">Team Captains</h2>
       <div class="photo-grid" style="margin-bottom:20px">
-        <div class="photo-card landscape"><img src="Images/captains1.png" alt="Team Captains"><div class="photo-card-label">Team Captains</div></div>
-        <div class="photo-card landscape"><img src="Images/captains2.png" alt="Team Captains"><div class="photo-card-label">Team Captains</div></div>
+        <div class="photo-card landscape"><img src="Images/captains1.png" alt="Team Captains"></div>
+        <div class="photo-card landscape"><img src="Images/captains2.png" alt="Team Captains"></div>
       </div>
       <div id="captainsList" class="grid three"></div>
     </section>
+
+    <hr class="section-divider">
+
+    <div class="photo-grid">
+      <div class="photo-card"><img src="Images/rive1.png" alt="Rive"></div>
+      <div class="photo-card"><img src="Images/samf1.png" alt="Sam F."></div>
+      <div class="photo-card"><img src="Images/spencer1.png" alt="Spencer"></div>
+      <div class="photo-card"><img src="Images/white1.png" alt="White"></div>
+      <div class="photo-card"><img src="Images/zaleski1.png" alt="Zaleski"></div>
+    </div>
   </main>
 
   <footer class="site-footer">
@@ -87,7 +96,8 @@
   const safe = v => (v === null || v === undefined) ? "" : v;
   const renderAllAmericans = (container, dict) => {
     container.innerHTML = "";
-    Object.keys(dict).sort().forEach(year => {
+    // Sort years descending (most recent first)
+    Object.keys(dict).sort((a, b) => b.localeCompare(a)).forEach(year => {
       const entries = dict[year] || [];
       const ul = document.createElement("ul");
       ul.className = "compact";
@@ -116,7 +126,8 @@
     renderAllAmericans(document.getElementById("aaHM"), data.all_americans?.honorable_mention || {});
 
     const academicList = document.getElementById("academicList");
-    Object.keys(data.academic_all_americans || {}).sort().forEach(year => {
+    // Sort years descending
+    Object.keys(data.academic_all_americans || {}).sort((a, b) => b.localeCompare(a)).forEach(year => {
       const items = data.academic_all_americans[year] || [];
       const entries = items.map(x => x.position ? `${x.name} — ${x.position}` : x.name);
       const wrap = document.createElement("div");
@@ -131,30 +142,30 @@
     });
 
     const captainsList = document.getElementById("captainsList");
-    
-    // Custom grouping as requested
+
+    // Custom grouping — reversed so most recent years first
     const captainsData = data.team_captains || {};
     const customGroups = [
-      ["2025", "2024", "2023"], // 2024-2022
-      ["2022", "2021", "2019", "2018"], // 2021-2018 (skipping 2020)
-      ["2017", "2016", "2015"], // 2017-2015
-      ["2014", "2013", "2012", "2009-2011"] // 2014-2009 (combining 2009-2011 range)
+      ["2025", "2024", "2023"],
+      ["2022", "2021", "2019", "2018"],
+      ["2017", "2016", "2015"],
+      ["2014", "2013", "2012", "2009-2011"]
     ];
-    
+
     customGroups.forEach(group => {
       const card = document.createElement("article");
       card.className = "card";
-      
+
       group.forEach(year => {
         const items = captainsData[year] || [];
-        if (items.length > 0) { // Only add if there are captains for this year
+        if (items.length > 0) {
           const yearDiv = document.createElement("div");
           yearDiv.className = "year-group";
-          
+
           const yearH4 = document.createElement("h4");
           yearH4.textContent = year;
           yearDiv.appendChild(yearH4);
-          
+
           const ul = document.createElement("ul");
           ul.className = "compact";
           items.forEach(item => {
@@ -166,8 +177,7 @@
           card.appendChild(yearDiv);
         }
       });
-      
-      // Only append card if it has content
+
       if (card.children.length > 0) {
         captainsList.appendChild(card);
       }
@@ -181,7 +191,3 @@
   <script src="script.js"></script>
 </body>
 </html>
-
-
-
-

--- a/awards.html
+++ b/awards.html
@@ -30,16 +30,12 @@
   <main class="container">
     <section id="awards" aria-labelledby="awards-title">
       <h2 id="awards-title">NCFA National Awards</h2>
-      <div id="awardsCards" class="grid three"></div>
-      <div class="photo-section">
-        <p class="photo-section-title">Award Recipients</p>
-        <div class="photo-grid">
-          <div class="photo-card landscape">
-            <img src="Images/mikusWalshUntch.png" alt="Mikus, Walsh & Untch">
-            <div class="photo-card-label">Mikus · Walsh · Untch</div>
-          </div>
-        </div>
+
+      <div class="inline-photo">
+        <img src="Images/mikusWalshUntch.png" alt="Mikus, Walsh & Untch">
       </div>
+
+      <div id="awardsCards" class="grid three"></div>
     </section>
   </main>
 
@@ -77,5 +73,3 @@
   <script src="script.js"></script>
 </body>
 </html>
-
-

--- a/find-a-player.html
+++ b/find-a-player.html
@@ -70,7 +70,6 @@
     const lq = q.toLowerCase();
     const results = { aa: [], captain: [], award: [], stat: [] };
 
-    // All-Americans
     ["first_team", "second_team", "honorable_mention"].forEach(team => {
       Object.entries(data.all_americans?.[team] || {}).forEach(([year, entries]) => {
         (entries || []).forEach(e => {
@@ -81,7 +80,6 @@
       });
     });
 
-    // Academic All-Americans
     Object.entries(data.academic_all_americans || {}).forEach(([year, entries]) => {
       (entries || []).forEach(e => {
         if (safe(e.name).toLowerCase().includes(lq) || safe(e.position).toLowerCase().includes(lq)) {
@@ -90,7 +88,6 @@
       });
     });
 
-    // Team captains
     Object.entries(data.team_captains || {}).forEach(([year, entries]) => {
       (entries || []).forEach(e => {
         if (safe(e.name).toLowerCase().includes(lq) || safe(e.position).toLowerCase().includes(lq)) {
@@ -99,7 +96,6 @@
       });
     });
 
-    // Awards
     (data.awards || []).forEach(a => {
       const haystack = [safe(a.person), safe(a.title), safe(a.role), safe(a.narrative)].join(" ").toLowerCase();
       if (haystack.includes(lq)) {
@@ -107,7 +103,6 @@
       }
     });
 
-    // Stat leaders
     Object.entries(data.stats || {}).forEach(([block, subcats]) => {
       Object.entries(subcats || {}).forEach(([sub, items]) => {
         (items || []).forEach(item => {

--- a/game-by-game.html
+++ b/game-by-game.html
@@ -30,29 +30,28 @@
   <main class="container">
     <section id="game-by-game" aria-labelledby="gbg-title">
       <h2 id="gbg-title">Game-by-Game Results</h2>
-      <div class="photo-section">
-        <p class="photo-section-title">Season Highlights</p>
-        <div class="photo-grid">
-          <div class="photo-card landscape">
-            <img src="Images/2021NattyChamps.png" alt="2021 National Champions">
-            <div class="photo-card-label">2021 National Champions</div>
-          </div>
-          <div class="photo-card landscape">
-            <img src="Images/2023Denison.png" alt="2023 vs. Denison">
-            <div class="photo-card-label">2023 vs. Denison</div>
-          </div>
-          <div class="photo-card landscape">
-            <img src="Images/2023Defense1.png" alt="2023 Defense">
-            <div class="photo-card-label">2023 Defense</div>
-          </div>
-          <div class="photo-card landscape">
-            <img src="Images/2023Defense2.png" alt="2023 Defense">
-            <div class="photo-card-label">2023 Defense</div>
-          </div>
-        </div>
+
+      <div class="inline-photo">
+        <img src="Images/2021NattyChamps.png" alt="2021 National Champions">
       </div>
 
       <div id="gbgContainer" class="accordion"></div>
+
+      <div class="inline-photo">
+        <img src="Images/2023Denison.png" alt="2023 vs. Denison">
+      </div>
+
+      <div id="gbgContainer2" class="accordion"></div>
+
+      <div class="inline-photo">
+        <img src="Images/2023Defense1.png" alt="2023 Defense">
+      </div>
+
+      <div id="gbgContainer3" class="accordion"></div>
+
+      <div class="inline-photo">
+        <img src="Images/2023Defense2.png" alt="2023 Defense">
+      </div>
     </section>
   </main>
 
@@ -64,13 +63,6 @@
 
   <script>
   const safe = v => (v === null || v === undefined) ? "" : v;
-  const filterable = (root, input) => {
-    const q = input.value.trim().toLowerCase();
-    root.querySelectorAll("[data-search]").forEach(el => {
-      const text = el.getAttribute("data-search") || el.textContent || "";
-      el.style.display = text.toLowerCase().includes(q) ? "" : "none";
-    });
-  };
   const parseGameRow = g => {
     const outcome = safe(g.outcome);
     const site = safe(g.site);
@@ -99,10 +91,24 @@
     if (!res.ok) throw new Error(`data.json not found (${res.status})`);
     const data = await res.json();
 
-    const gbgContainer = document.getElementById("gbgContainer");
-    (data.game_by_game || []).forEach(season => {
+    // Reverse: most recent season first
+    const seasons = (data.game_by_game || []).slice().reverse();
+
+    // Split seasons into 3 groups for interspersing with photos
+    const groupSize = Math.ceil(seasons.length / 3);
+    const containers = [
+      document.getElementById("gbgContainer"),
+      document.getElementById("gbgContainer2"),
+      document.getElementById("gbgContainer3")
+    ];
+
+    seasons.forEach((season, i) => {
+      const containerIdx = Math.min(Math.floor(i / groupSize), 2);
+      const container = containers[containerIdx];
+
       const details = document.createElement("details");
       details.className = "card";
+      if (i === 0) details.open = true;
       const summary = document.createElement("summary");
       summary.textContent = season.season_header || "Season";
       details.appendChild(summary);
@@ -130,7 +136,7 @@
       });
       tblWrap.appendChild(table);
       details.appendChild(tblWrap);
-      gbgContainer.appendChild(details);
+      container.appendChild(details);
     });
   }
   init().catch(err => {
@@ -141,5 +147,3 @@
   <script src="script.js"></script>
 </body>
 </html>
-
-

--- a/index.html
+++ b/index.html
@@ -50,35 +50,22 @@
   </footer>
 
   <script>
-    // Scroll-triggered animation for stats
     function animateStats() {
       const statsGrid = document.querySelector('.stats-grid');
       const stats = document.querySelectorAll('.stat');
-      
-      // Check if stats grid is in viewport
       const rect = statsGrid.getBoundingClientRect();
       const isInView = rect.top < window.innerHeight && rect.bottom > 0;
-      
       if (isInView) {
-        // Add visible class to grid
         statsGrid.classList.add('visible');
-        
-        // Animate individual stats with delay
         stats.forEach((stat, index) => {
           setTimeout(() => {
             stat.classList.add('animate');
-          }, index * 200); // 200ms delay between each stat
+          }, index * 200);
         });
       }
     }
-    
-    // Run animation on scroll
     window.addEventListener('scroll', animateStats);
-    
-    // Run animation on page load in case user is already scrolled down
     window.addEventListener('load', animateStats);
-    
-    // Run animation immediately if page is already loaded
     if (document.readyState === 'complete') {
       animateStats();
     }

--- a/record-vs-opponents.html
+++ b/record-vs-opponents.html
@@ -52,13 +52,6 @@
 
   <script>
   const safe = v => (v === null || v === undefined) ? "" : v;
-  const filterable = (root, input) => {
-    const q = input.value.trim().toLowerCase();
-    root.querySelectorAll("[data-search]").forEach(el => {
-      const text = el.getAttribute("data-search") || el.textContent || "";
-      el.style.display = text.toLowerCase().includes(q) ? "" : "none";
-    });
-  };
   async function init() {
     const res = await fetch("data.json");
     if (!res.ok) throw new Error(`data.json not found (${res.status})`);
@@ -98,5 +91,3 @@
   <script src="script.js"></script>
 </body>
 </html>
-
-

--- a/stats.html
+++ b/stats.html
@@ -64,7 +64,6 @@
     });
     return card;
   };
-  // Enhanced search: matches player names within item.text or category names
   function renderStats(stats, query) {
     const grid = document.getElementById("statsGrid");
     grid.innerHTML = "";
@@ -77,7 +76,6 @@
 
     Object.keys(stats).forEach(block => {
       const subcats = stats[block] || {};
-      // If filtering by category, allow matching block or subcat names
       const blockMatches = q && block.toLowerCase().includes(q);
       const filtered = {};
       Object.keys(subcats).forEach(sub => {
@@ -105,5 +103,3 @@
   <script src="script.js"></script>
 </body>
 </html>
-
-

--- a/style.css
+++ b/style.css
@@ -1,21 +1,29 @@
-@import url('https://fonts.googleapis.com/css2?family=Barlow+Condensed:wght@700;900&family=Inter:wght@400;500;600;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Oswald:wght@400;500;600;700&family=Source+Serif+4:ital,wght@0,400;0,600;1,400&family=JetBrains+Mono:wght@500&display=swap');
 
 /* ── Tokens ── */
 :root {
-  --bg:        #0a0d11;
-  --panel:     #131720;
-  --panel-2:   #1a202e;
-  --text:      #e9ecf1;
-  --muted:     #8892a0;
+  --bg:        #0b0c0f;
+  --panel:     #141518;
+  --panel-2:   #1c1d22;
+  --panel-3:   #232429;
+  --text:      #e4e2de;
+  --muted:     #8a8680;
   --brand:     #bb0000;
-  --brand-2:   #e02020;
-  --link:      #60a5fa;
-  --border:    #252d3d;
-  --shadow:    0 8px 28px rgba(0,0,0,0.5);
-  --radius:    12px;
-  --f-head:    'Barlow Condensed', system-ui, sans-serif;
-  --f-body:    'Inter', system-ui, sans-serif;
-  --ease:      150ms ease;
+  --brand-2:   #d41a1a;
+  --brand-glow: rgba(187, 0, 0, 0.35);
+  --accent:    #c8a54e;
+  --link:      #c8a54e;
+  --border:    #2a2b30;
+  --border-2:  #38393f;
+  --shadow:    0 8px 32px rgba(0,0,0,0.55);
+  --shadow-lg: 0 16px 48px rgba(0,0,0,0.7);
+  --radius:    10px;
+  --radius-lg: 16px;
+  --f-head:    'Oswald', sans-serif;
+  --f-body:    'Source Serif 4', Georgia, serif;
+  --f-mono:    'JetBrains Mono', monospace;
+  --ease:      200ms ease;
+  --ease-slow: 450ms cubic-bezier(0.25, 0.46, 0.45, 0.94);
 }
 
 /* ── Reset ── */
@@ -27,44 +35,71 @@ html, body {
   background: var(--bg);
   color: var(--text);
   min-height: 100vh;
-  font: 15px/1.65 var(--f-body);
+  font: 15px/1.72 var(--f-body);
   -webkit-font-smoothing: antialiased;
 }
 
-a { color: var(--link); text-decoration: none; }
+/* Subtle grain texture on body */
+body::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 9999;
+  opacity: 0.025;
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+}
+
+a { color: var(--link); text-decoration: none; transition: color var(--ease); }
 a:hover { color: #fff; }
 .muted { color: var(--muted); }
 
 /* ── Typography ── */
 h1 {
   font-family: var(--f-head);
-  font-weight: 900;
-  font-size: clamp(22px, 4vw, 32px);
-  letter-spacing: 0.02em;
+  font-weight: 700;
+  font-size: clamp(22px, 3.5vw, 30px);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
   margin: 8px 0 0;
 }
 h2 {
   font-family: var(--f-head);
-  font-weight: 700;
+  font-weight: 600;
   font-size: clamp(20px, 3vw, 26px);
-  letter-spacing: 0.02em;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
   margin-top: 28px;
-  border-left: 4px solid var(--brand);
-  padding-left: 12px;
+  padding-left: 14px;
+  border-left: 3px solid var(--brand);
+  position: relative;
+}
+h2::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  bottom: -4px;
+  width: 60px;
+  height: 1px;
+  background: var(--brand);
+  opacity: 0.5;
 }
 h3 {
   font-family: var(--f-head);
-  font-weight: 700;
-  font-size: 19px;
+  font-weight: 600;
+  font-size: 18px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
   margin: 6px 0 10px;
 }
 h4 {
-  font-size: 12px;
+  font-size: 11px;
   font-weight: 600;
   text-transform: uppercase;
-  letter-spacing: 0.07em;
+  letter-spacing: 0.1em;
   color: var(--muted);
-  margin: 12px 0 6px;
+  margin: 14px 0 6px;
+  font-family: var(--f-head);
 }
 
 /* ── Layout ── */
@@ -76,13 +111,15 @@ h4 {
 
 /* ── Header ── */
 .site-header {
-  background: linear-gradient(180deg, var(--panel-2), var(--panel));
+  background: var(--panel);
   border-bottom: 1px solid var(--border);
   position: sticky;
   top: 0;
   z-index: 100;
   width: 100%;
-  box-shadow: 0 2px 20px rgba(0,0,0,0.5);
+  box-shadow: 0 2px 24px rgba(0,0,0,0.6);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
 }
 
 .site-header.minimized {
@@ -92,7 +129,7 @@ h4 {
   right: 20px;
   width: auto;
   border-radius: 50px;
-  box-shadow: var(--shadow);
+  box-shadow: var(--shadow-lg);
   z-index: 1000;
 }
 .site-header.minimized .container { padding: 8px 16px; }
@@ -102,33 +139,40 @@ h4 {
 body.header-minimized { padding-top: 0; }
 
 .subtitle {
-  margin: 4px 0 10px;
+  margin: 2px 0 8px;
   color: var(--muted);
-  font-size: 14px;
+  font-size: 12px;
+  font-family: var(--f-head);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
 }
 
 /* ── Nav ── */
 .top-nav {
   display: flex;
   flex-wrap: wrap;
-  gap: 6px;
-  margin: 8px 0 12px;
+  gap: 5px;
+  margin: 6px 0 10px;
 }
 .top-nav a {
   color: var(--muted);
-  padding: 5px 13px;
+  padding: 5px 14px;
   border: 1px solid var(--border);
   border-radius: 999px;
-  font-size: 13px;
+  font-size: 12px;
   font-weight: 500;
+  font-family: var(--f-head);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
   background: transparent;
-  transition: background var(--ease), color var(--ease), border-color var(--ease);
+  transition: background var(--ease), color var(--ease), border-color var(--ease), box-shadow var(--ease);
 }
 .top-nav a:hover,
 .top-nav a.active {
   background: var(--brand);
   border-color: var(--brand-2);
   color: #fff;
+  box-shadow: 0 0 16px var(--brand-glow);
 }
 
 /* ── Minimize button ── */
@@ -171,7 +215,7 @@ body.header-minimized { padding-top: 0; }
 .image-overlay {
   position: absolute;
   inset: 0;
-  opacity: 0.5;
+  opacity: 0.4;
 }
 .image-overlay img,
 .overlay-img {
@@ -180,12 +224,13 @@ body.header-minimized { padding-top: 0; }
   object-fit: cover;
   object-position: center 30%;
 }
-.overlay-text {
+/* Dark vignette over hero image */
+.image-section::after {
+  content: '';
   position: absolute;
-  bottom: 0; left: 0; right: 0;
-  background: linear-gradient(transparent, rgba(0,0,0,0.8));
-  color: #fff;
-  padding: 20px;
+  inset: 0;
+  background: radial-gradient(ellipse at center, transparent 20%, rgba(11,12,15,0.85) 80%);
+  pointer-events: none;
 }
 
 /* Stats grid */
@@ -202,46 +247,46 @@ body.header-minimized { padding-top: 0; }
   z-index: 1;
   opacity: 0;
   transform: translateY(60px);
-  transition: opacity 0.55s ease, transform 0.55s ease;
+  transition: opacity 0.6s var(--ease-slow), transform 0.6s var(--ease-slow);
 }
 .stats-grid.visible { opacity: 1; transform: translateY(0); }
 
 .stat {
   font-family: var(--f-head);
-  font-weight: 900;
-  font-size: clamp(68px, 9vw, 108px);
+  font-weight: 700;
+  font-size: clamp(64px, 9vw, 100px);
   text-align: center;
   color: #fff;
   text-shadow:
-    0 0 40px rgba(187,0,0,0.7),
+    0 0 50px var(--brand-glow),
     2px  2px 0 #000,
    -2px -2px 0 #000,
     2px -2px 0 #000,
    -2px  2px 0 #000;
   opacity: 0;
   transform: translateY(28px);
-  transition: opacity 0.45s ease, transform 0.45s ease;
+  transition: opacity 0.5s ease, transform 0.5s ease;
 }
 .stat.animate { opacity: 1; transform: translateY(0); }
 .stat span {
   display: block;
   font-family: var(--f-head);
-  font-weight: 700;
-  font-size: clamp(12px, 1.4vw, 15px);
+  font-weight: 500;
+  font-size: clamp(11px, 1.3vw, 14px);
   text-transform: uppercase;
-  letter-spacing: 0.1em;
-  color: rgba(255,255,255,0.88);
-  text-shadow: 1px 1px 4px rgba(0,0,0,0.9);
-  margin-top: 4px;
+  letter-spacing: 0.14em;
+  color: rgba(255,255,255,0.75);
+  text-shadow: 1px 1px 6px rgba(0,0,0,0.9);
+  margin-top: 6px;
 }
-.stat.big   { grid-column: 2/3; grid-row: 2/3; font-size: clamp(78px, 10vw, 118px); }
+.stat.big   { grid-column: 2/3; grid-row: 2/3; font-size: clamp(74px, 10vw, 112px); }
 .stat.aa    { grid-column: 1/2; grid-row: 1/2; }
 .stat.conf  { grid-column: 3/4; grid-row: 1/2; }
 .stat.awards{ grid-column: 1/2; grid-row: 3/4; }
 .stat.undef { grid-column: 3/4; grid-row: 3/4; }
 
 /* ── Grid ── */
-.grid { display: grid; gap: 16px; }
+.grid { display: grid; gap: 18px; }
 .grid.two   { grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); }
 .grid.three { grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); }
 
@@ -249,15 +294,29 @@ body.header-minimized { padding-top: 0; }
 .card {
   background: var(--panel);
   border: 1px solid var(--border);
-  border-top: 3px solid transparent;
   border-radius: var(--radius);
-  padding: 16px;
+  padding: 18px;
   box-shadow: var(--shadow);
-  transition: border-top-color var(--ease), box-shadow var(--ease), transform var(--ease);
+  transition: border-color var(--ease), box-shadow var(--ease), transform var(--ease);
+  position: relative;
+  overflow: hidden;
 }
+/* Subtle top accent line */
+.card::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 2px;
+  background: linear-gradient(90deg, var(--brand), transparent 80%);
+  opacity: 0;
+  transition: opacity var(--ease);
+}
+.card:hover::before { opacity: 1; }
 .card:hover {
-  border-top-color: var(--brand);
-  box-shadow: 0 14px 40px rgba(0,0,0,0.6);
+  border-color: var(--border-2);
+  box-shadow: var(--shadow-lg);
   transform: translateY(-2px);
 }
 .card.award h3 { color: #fff; }
@@ -266,25 +325,31 @@ body.header-minimized { padding-top: 0; }
 .fade-up {
   opacity: 0;
   transform: translateY(22px);
-  transition: opacity 0.4s ease, transform 0.4s ease;
+  transition: opacity 0.45s ease, transform 0.45s ease;
 }
 .fade-up.visible { opacity: 1; transform: translateY(0); }
 
 /* ── Tables ── */
-.table-wrap { overflow: auto; border-radius: 10px; }
+.table-wrap { overflow: auto; border-radius: var(--radius); }
 table { width: 100%; border-collapse: collapse; min-width: 400px; }
-th, td { text-align: left; padding: 9px 12px; border-bottom: 1px solid var(--border); vertical-align: top; }
+th, td {
+  text-align: left;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--border);
+  vertical-align: top;
+  font-size: 14px;
+}
 thead th {
   position: sticky;
   top: 0;
   background: var(--panel-2);
   z-index: 1;
   font-family: var(--f-head);
-  font-size: 13px;
+  font-size: 11px;
   text-transform: uppercase;
-  letter-spacing: 0.06em;
+  letter-spacing: 0.1em;
   color: var(--muted);
-  font-weight: 700;
+  font-weight: 600;
 }
 tfoot td { color: var(--muted); }
 
@@ -292,10 +357,10 @@ tfoot td { color: var(--muted); }
 .rank-list { margin: 0; padding-left: 0; list-style: none; }
 .rank-list.compact li { margin: 3px 0; font-size: 14px; }
 .rank {
-  color: var(--muted);
+  color: var(--accent);
   margin-right: 6px;
-  font-family: var(--f-head);
-  font-weight: 700;
+  font-family: var(--f-mono);
+  font-weight: 500;
   font-size: 12px;
 }
 
@@ -309,6 +374,7 @@ tfoot td { color: var(--muted); }
   border: 1px solid var(--border);
   margin-left: 6px;
   font-size: 11px;
+  font-family: var(--f-mono);
   vertical-align: middle;
 }
 .badge {
@@ -316,15 +382,15 @@ tfoot td { color: var(--muted); }
   min-width: 28px;
   text-align: center;
   padding: 3px 8px;
-  border-radius: 6px;
+  border-radius: 5px;
   font-size: 12px;
-  font-weight: 700;
+  font-weight: 600;
   font-family: var(--f-head);
-  letter-spacing: 0.05em;
+  letter-spacing: 0.06em;
 }
-.badge.win     { background: rgba(16,185,129,0.15); color: #34d399; border: 1px solid rgba(16,185,129,0.3); }
-.badge.loss    { background: rgba(239,68,68,0.15);  color: #f87171; border: 1px solid rgba(239,68,68,0.3); }
-.badge.neutral { background: rgba(96,165,250,0.15); color: #93c5fd; border: 1px solid rgba(96,165,250,0.3); }
+.badge.win     { background: rgba(16,185,129,0.12); color: #34d399; border: 1px solid rgba(16,185,129,0.25); }
+.badge.loss    { background: rgba(239,68,68,0.12);  color: #f87171; border: 1px solid rgba(239,68,68,0.25); }
+.badge.neutral { background: rgba(200,165,78,0.12); color: var(--accent); border: 1px solid rgba(200,165,78,0.25); }
 
 /* ── Accordion ── */
 .accordion details { margin-bottom: 8px; }
@@ -333,24 +399,25 @@ details > summary {
   cursor: pointer;
   list-style: none;
   font-family: var(--f-head);
-  font-weight: 700;
-  font-size: 19px;
-  letter-spacing: 0.02em;
+  font-weight: 600;
+  font-size: 18px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
   color: #fff;
-  padding: 12px 16px;
+  padding: 13px 18px;
   background: var(--panel);
   border: 1px solid var(--border);
   border-radius: var(--radius);
-  transition: background var(--ease), border-color var(--ease);
+  transition: background var(--ease), border-color var(--ease), box-shadow var(--ease);
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: 12px;
 }
 details > summary::before {
   content: '›';
   font-size: 22px;
   color: var(--brand);
-  transition: transform 0.2s ease;
+  transition: transform 0.25s ease;
   flex-shrink: 0;
 }
 details[open] > summary::before { transform: rotate(90deg); }
@@ -359,6 +426,7 @@ details[open] > summary {
   border-bottom-right-radius: 0;
   border-color: var(--brand);
   background: var(--panel-2);
+  box-shadow: 0 0 20px var(--brand-glow);
 }
 details > summary:hover { background: var(--panel-2); border-color: var(--brand); }
 details > summary::-webkit-details-marker { display: none; }
@@ -366,7 +434,7 @@ details > summary::-webkit-details-marker { display: none; }
 details[open] .table-wrap {
   border-top-left-radius: 0;
   border-top-right-radius: 0;
-  animation: fadeDown 0.2s ease;
+  animation: fadeDown 0.25s ease;
 }
 @keyframes fadeDown {
   from { opacity: 0; transform: translateY(-6px); }
@@ -381,16 +449,16 @@ details[open] .table-wrap {
 ul.compact, .year-groups ul { margin: 6px 0 0; padding-left: 18px; }
 
 /* ── Photo grid ── */
-.photo-section { margin: 36px 0 12px; }
+.photo-section { margin: 36px 0 16px; }
 .photo-section-title {
   font-family: var(--f-head);
-  font-size: 18px;
-  font-weight: 700;
+  font-size: 16px;
+  font-weight: 600;
   text-transform: uppercase;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.1em;
   color: var(--muted);
   margin-bottom: 14px;
-  border-left: 4px solid var(--brand);
+  border-left: 3px solid var(--brand);
   padding-left: 12px;
 }
 .photo-grid {
@@ -400,12 +468,13 @@ ul.compact, .year-groups ul { margin: 6px 0 0; padding-left: 18px; }
 }
 .photo-card {
   position: relative;
-  border-radius: 10px;
+  border-radius: var(--radius);
   overflow: hidden;
   border: 1px solid var(--border);
   background: var(--panel);
   aspect-ratio: 3/4;
   box-shadow: var(--shadow);
+  transition: transform 0.35s ease, box-shadow 0.35s ease;
 }
 .photo-card.landscape {
   aspect-ratio: 16/9;
@@ -417,22 +486,42 @@ ul.compact, .year-groups ul { margin: 6px 0 0; padding-left: 18px; }
   object-fit: cover;
   object-position: top;
   display: block;
-  transition: transform 0.35s ease, filter 0.35s ease;
+  transition: transform 0.4s ease, filter 0.4s ease;
+}
+.photo-card:hover {
+  transform: translateY(-3px);
+  box-shadow: var(--shadow-lg);
 }
 .photo-card:hover img { transform: scale(1.06); filter: brightness(1.08); }
+
+/* Photo card labels — hidden by default */
 .photo-card-label {
-  position: absolute;
-  bottom: 0; left: 0; right: 0;
-  background: linear-gradient(transparent, rgba(0,0,0,0.78));
-  color: #fff;
-  font-family: var(--f-head);
-  font-size: 12px;
-  font-weight: 700;
-  letter-spacing: 0.05em;
-  text-transform: uppercase;
-  padding: 22px 10px 8px;
-  text-align: center;
+  display: none;
 }
+
+/* Inline photo break (images interspersed in content) */
+.inline-photo {
+  border-radius: var(--radius);
+  overflow: hidden;
+  border: 1px solid var(--border);
+  background: var(--panel);
+  box-shadow: var(--shadow);
+  margin: 24px 0;
+  transition: transform 0.35s ease, box-shadow 0.35s ease;
+}
+.inline-photo img {
+  width: 100%;
+  height: auto;
+  max-height: 320px;
+  object-fit: cover;
+  display: block;
+  transition: transform 0.4s ease;
+}
+.inline-photo:hover {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-lg);
+}
+.inline-photo:hover img { transform: scale(1.03); }
 
 /* Card images (team-records) */
 .card-image {
@@ -445,7 +534,7 @@ ul.compact, .year-groups ul { margin: 6px 0 0; padding-left: 18px; }
 .responsive-image {
   max-width: 100%;
   height: auto;
-  border-radius: 8px;
+  border-radius: var(--radius);
   box-shadow: var(--shadow);
   transition: transform 0.3s ease;
 }
@@ -456,6 +545,14 @@ ul.compact, .year-groups ul { margin: 6px 0 0; padding-left: 18px; }
   font-size: 13px;
   text-align: center;
   font-style: italic;
+}
+
+/* ── Divider (visual break between sections) ── */
+.section-divider {
+  border: none;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, var(--border-2) 30%, var(--border-2) 70%, transparent);
+  margin: 36px 0;
 }
 
 /* ── Find-a-player: search hero ── */
@@ -491,7 +588,7 @@ ul.compact, .year-groups ul { margin: 6px 0 0; padding-left: 18px; }
 }
 .player-search-input:focus {
   border-color: var(--brand);
-  box-shadow: 0 0 0 3px rgba(187,0,0,0.18);
+  box-shadow: 0 0 0 3px var(--brand-glow);
 }
 
 /* ── Find-a-player: results ── */
@@ -500,6 +597,8 @@ ul.compact, .year-groups ul { margin: 6px 0 0; padding-left: 18px; }
   color: var(--muted);
   margin-bottom: 16px;
   min-height: 20px;
+  font-family: var(--f-head);
+  letter-spacing: 0.04em;
 }
 .results-empty {
   text-align: center;
@@ -510,10 +609,10 @@ ul.compact, .year-groups ul { margin: 6px 0 0; padding-left: 18px; }
 .result-group { margin-bottom: 28px; }
 .result-group-title {
   font-family: var(--f-head);
-  font-size: 15px;
-  font-weight: 700;
+  font-size: 14px;
+  font-weight: 600;
   text-transform: uppercase;
-  letter-spacing: 0.09em;
+  letter-spacing: 0.1em;
   color: var(--muted);
   margin-bottom: 10px;
   padding-bottom: 7px;
@@ -535,20 +634,20 @@ ul.compact, .year-groups ul { margin: 6px 0 0; padding-left: 18px; }
 .result-item:hover { border-color: var(--brand); background: var(--panel-2); }
 .result-name   { font-weight: 600; color: var(--text); min-width: 150px; }
 .result-detail { color: var(--muted); flex: 1; font-size: 13px; }
-.result-year   { font-family: var(--f-head); font-size: 13px; font-weight: 700; color: var(--muted); white-space: nowrap; }
+.result-year   { font-family: var(--f-mono); font-size: 13px; font-weight: 500; color: var(--muted); white-space: nowrap; }
 .result-cat {
   display: inline-block;
   padding: 2px 9px;
   border-radius: 999px;
-  font-size: 11px;
-  font-weight: 700;
+  font-size: 10px;
+  font-weight: 600;
   font-family: var(--f-head);
   text-transform: uppercase;
-  letter-spacing: 0.05em;
+  letter-spacing: 0.06em;
   white-space: nowrap;
 }
 .cat-aa      { background: rgba(187,0,0,0.15);    color: #f87171; border: 1px solid rgba(187,0,0,0.3); }
-.cat-captain { background: rgba(245,158,11,0.15); color: #fbbf24; border: 1px solid rgba(245,158,11,0.3); }
+.cat-captain { background: rgba(200,165,78,0.15); color: var(--accent); border: 1px solid rgba(200,165,78,0.3); }
 .cat-award   { background: rgba(99,102,241,0.15); color: #a5b4fc; border: 1px solid rgba(99,102,241,0.3); }
 .cat-stat    { background: rgba(16,185,129,0.15); color: #34d399; border: 1px solid rgba(16,185,129,0.3); }
 
@@ -558,10 +657,13 @@ ul.compact, .year-groups ul { margin: 6px 0 0; padding-left: 18px; }
 /* ── Footer ── */
 .site-footer {
   border-top: 1px solid var(--border);
-  margin-top: 40px;
-  padding: 16px 0 32px;
+  margin-top: 48px;
+  padding: 20px 0 36px;
   color: var(--muted);
-  font-size: 13px;
+  font-size: 12px;
+  font-family: var(--f-head);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
 }
 
 /* ── Error ── */
@@ -573,6 +675,7 @@ pre.error {
   padding: 14px;
   margin: 16px;
   color: #fca5a5;
+  font-family: var(--f-mono);
 }
 
 /* ── Desktop grid overrides (team-records) ── */
@@ -617,10 +720,20 @@ pre.error {
   .photo-card.landscape { grid-column: span 1; aspect-ratio: 4/3; }
 
   .result-name { min-width: auto; }
+
+  .inline-photo img { max-height: 220px; }
 }
 
 @media (max-width: 480px) {
-  .top-nav a { font-size: 12px; padding: 4px 10px; }
+  .top-nav a { font-size: 11px; padding: 4px 10px; }
   .photo-grid { grid-template-columns: 1fr; }
   .photo-card.landscape { aspect-ratio: 16/9; }
+}
+
+/* ── Reduced motion ── */
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    transition-duration: 0.01ms !important;
+  }
 }

--- a/team-records.html
+++ b/team-records.html
@@ -44,9 +44,7 @@
         </article>
         <div class="card-image">
           <img src="Images/grega1.png" alt="Head Coach James Grega during 2019 NCFA title game" class="responsive-image">
-          <p class="image-caption">Head Coach Grega — 2019 NCFA Title Game</p>
           <img src="Images/grega2.png" alt="Head Coach James Grega" class="responsive-image" style="margin-top:12px">
-          <p class="image-caption">Head Coach James Grega</p>
         </div>
         <article class="card">
           <h3>Points (Game)</h3>
@@ -126,5 +124,3 @@
   <script src="script.js"></script>
 </body>
 </html>
-
-


### PR DESCRIPTION
- Restyle with Oswald/Source Serif 4 fonts, gold accents, grain texture
- Reverse game-by-game and all-americans/captains to show 2025 first
- Spread images throughout pages instead of grouping at bottom
- Remove visible text overlays from all photo cards
- Add reduced-motion media query for accessibility